### PR TITLE
refactor(PR2TRIGGER): 忽略包含 'release` 的分支或 `base_ref` 是 `main`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { getOctokit } from '@actions/github';
 import { labelTrigger } from './projects/labelTrigger';
 import { prTrigger } from './projects/prTrigger';
 import { issueTrigger } from './projects/issueTrigger';
+import { env } from 'node:process';
 
 type ProjectType = 'ISSUE2TRIGGER' | 'PR2TRIGGER' | 'LABEL2TRIGGER';
 
@@ -27,22 +28,31 @@ async function run(): Promise<void> {
 
     coreInfo(`PROJECT_TYPE: ${PROJECT_TYPE}`);
 
-    if (PROJECT_TYPE === 'LABEL2TRIGGER') {
-      await labelTrigger(octokit, Number(PROJECT_ID));
-      return;
+    switch (PROJECT_TYPE) {
+      case 'LABEL2TRIGGER':
+        await labelTrigger(octokit, Number(PROJECT_ID));
+        return;
+      case 'PR2TRIGGER':
+        // 如果是包含 'release' 的分支或 base_ref 是 'main'，则不触发 PR 逻辑
+        if (
+          env?.GITHUB_HEAD_REF?.includes('release') ||
+          env?.GITHUB_BASE_REF === 'main'
+        ) {
+          coreInfo(
+            `GITHUB_HEAD_REF: ${env?.GITHUB_HEAD_REF}, GITHUB_BASE_REF: ${env?.GITHUB_BASE_REF}`
+          );
+        } else {
+          await prTrigger(octokit, Number(PROJECT_ID));
+        }
+        return;
+      case 'ISSUE2TRIGGER':
+        await issueTrigger(octokit, Number(PROJECT_ID));
+        return;
+      default:
+        coreSetFailed(
+          "PROJECT_TYPE is not valid, not 'ISSUE2TRIGGER', 'PR2TRIGGER', or 'LABEL2TRIGGER'"
+        );
     }
-    if (PROJECT_TYPE === 'PR2TRIGGER') {
-      await prTrigger(octokit, Number(PROJECT_ID));
-      return;
-    }
-    if (PROJECT_TYPE === 'ISSUE2TRIGGER') {
-      await issueTrigger(octokit, Number(PROJECT_ID));
-      return;
-    }
-
-    coreSetFailed(
-      "PROJECT_TYPE is not valid, not 'ISSUE2TRIGGER', 'PR2TRIGGER', or 'LABEL2TRIGGER'"
-    );
   } catch (error: unknown) {
     if (error instanceof Error) {
       coreSetFailed(error.message);


### PR DESCRIPTION
目前有些 pr 内提及的 issue 可能不存在 Project 内，所以这里进行规则判断:

- 当某个分支名包含 `release` (如 `release/next`) 则不触发 `project-pr-trigger` 
- 当 pr 提到 `main` 分支的时候，不触发 `project-pr-trigger` 